### PR TITLE
Implemented Haven Offshore transaction logic (XHV <> xUSD <> xAssets)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,16 @@ find_package(Boost COMPONENTS
     thread REQUIRED
 )
 
+add_definitions(-DAUTO_INITIALIZE_EASYLOGGINGPP)
+
 set(MONERO_SRC "contrib/monero-core-custom")
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories("src")
 include_directories(${MONERO_SRC})
+include_directories("${MONERO_SRC}/easylogging++")
 include_directories("${MONERO_SRC}/epee/include")
 include_directories("${MONERO_SRC}/common")
-include_directories("${MONERO_SRC}/vtlogger")
 include_directories("${MONERO_SRC}/crypto")
 include_directories("${MONERO_SRC}/cryptonote_basic")
 include_directories("${MONERO_SRC}/multisig")
@@ -30,6 +32,7 @@ include_directories("${MONERO_SRC}/cryptonote_protocol")
 include_directories("${MONERO_SRC}/wallet")
 include_directories("${MONERO_SRC}/rpc")
 include_directories("${MONERO_SRC}/mnemonics")
+include_directories("${MONERO_SRC}/offshore")
 include_directories("${MONERO_SRC}/contrib/libsodium/include") # support sodium/… paths
 include_directories("${MONERO_SRC}/contrib/libsodium/include/sodium")
 include_directories("test")
@@ -104,8 +107,9 @@ set(
     ${MONERO_SRC}/ringct/bulletproofs.cc
     ${MONERO_SRC}/ringct/multiexp.cc
     ${MONERO_SRC}/mnemonics/electrum-words.cpp
-    ${MONERO_SRC}/vtlogger/logger.cpp
+    ${MONERO_SRC}/offshore/pricing_record.cpp
     ${MONERO_SRC}/contrib/libsodium/src/crypto_verify/verify.c
+    ${MONERO_SRC}/easylogging++/easylogging++.cc
 )
 # needed for slow-hash
 add_compile_options(-maes)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Useful for displaying an estimated fee – To obtain exact fees, see "Creating a
 	* `n_outputs: UInt32String`
 	* `extra_size: UInt32String`
 	* `bulletproof: BoolString`
+	* `clsag: BoolString`
 
 * Returns: `retVal: UInt32String`
 
@@ -311,16 +312,40 @@ The values which must be passed between functions have (almost entirely) consist
 
 * `CreateTransactionErrorCode: UInt32String` defined in `monero_transfer_utils.hpp`; to remain stable within major versions
 
+* `PricingRecord: Dictionary` with 
+	* `blockchain_height: UInt64String`
+	* `pricing_record: Dictionary` with
+		* `sig_hex: String`
+		* `unused1: UInt64String`
+		* `unused2: UInt64String`
+		* `unused3: UInt64String`
+		* `xAG: UInt64String`
+		* `xAU: UInt64String`
+		* `xAUD: UInt64String`
+		* `xBTC: UInt64String`
+		* `xCAD: UInt64String`
+		* `xCHF: UInt64String`
+		* `xCNY: UInt64String`
+		* `xERU: UInt64String`
+		* `xGBP: UInt64String`
+		* `xJPY: UInt64String`
+		* `xNOK: UInt64String`
+		* `xNZD: UInt64String`
+		* `xUSD: UInt64String`
+
 ##### `send_step1__prepare_params_for_get_decoys`
 
 * Args: 
 	* `sending_amount: UInt64String`
 	* `is_sweeping: BoolString`
+	* `from_asset_type: String`
+	* `to_asset_type: String`
 	* `priority: UInt32String` of `1`–`4`
 	* `fee_per_b: UInt64String`
 	* `fee_mask: UInt64String`
 	* `fork_version: UInt8String`
 	* `unspent_outs: [UnspentOutput]` - fully parsed server response
+	* `pr: [PricingRecord]` - fully parsed server response
 	* `payment_id_string: Optional<String>`
 	* `passedIn_attemptAt_fee: Optional<UInt64String>`
 	
@@ -339,10 +364,10 @@ The values which must be passed between functions have (almost entirely) consist
 	*OR* 
 	
 	* `mixin: UInt32String` use this for requesting random outputs before step2
-	* `using_fee: UInt64String`
-	* `change_amount: UInt64String`
+	* `using_fee: UInt64String` expressed in same currency as `from_asset_type`
+	* `change_amount: UInt64String` expressed in same currency as `from_asset_type`
 	* `using_outs: [UnspentOutput]` passable directly to step2
-	* `final_total_wo_fee: UInt64String`
+	* `final_total_wo_fee: UInt64String` expressed in same currency as `from_asset_type`
 	
 
 ##### `send_step2__try_create_transaction`
@@ -352,6 +377,8 @@ The values which must be passed between functions have (almost entirely) consist
 	* `sec_viewKey_string: String`
 	* `sec_spendKey_string: String`
 	* `to_address_string: String`
+	* `from_asset_type: String`
+	* `to_asset_type: String`
 	* `final_total_wo_fee: UInt64String` returned by step1
 	* `change_amount: UInt64String` returned by step1
 	* `fee_amount: UInt64String` returned by step1
@@ -361,6 +388,8 @@ The values which must be passed between functions have (almost entirely) consist
 	* `fork_version: UInt8String`
 	* `using_outs: [UnspentOutput]` returned by step1
 	* `mix_outs: [MixAmountAndOuts]` defined below
+	* `current_height: UInt64String` obtained from API call
+	* `pr: [PricingRecord]` - fully parsed server response
 	* `unlock_time: UInt64String`
 	* `nettype_string: NettypeString`
 	* `payment_id_string: Optional<String>`

--- a/src/monero_fee_utils.cpp
+++ b/src/monero_fee_utils.cpp
@@ -64,7 +64,7 @@ uint64_t monero_fee_utils::estimated_tx_network_fee(
 ) {
 	uint64_t fee_multiplier = get_fee_multiplier(priority, default_priority(), get_fee_algorithm(use_fork_rules_fn), use_fork_rules_fn);
 	std::vector<uint8_t> extra; // blank extra
-	size_t est_tx_size = estimate_rct_tx_size(2, fixed_mixinsize(), 2, extra.size(), true/*bulletproof*/); // typically ~14kb post-rct, pre-bulletproofs
+	size_t est_tx_size = estimate_rct_tx_size(2, fixed_mixinsize(), 2, extra.size(), true/*bulletproof*/, true/*clsag*/); // typically ~14kb post-rct, pre-bulletproofs
 	uint64_t estimated_fee = calculate_fee_from_size(base_fee, est_tx_size, fee_multiplier);
 	//
 	return estimated_fee;
@@ -138,7 +138,7 @@ int monero_fee_utils::get_fee_algorithm(use_fork_rules_fn_type use_fork_rules_fn
 		return 1;
 	return 0;
 }
-size_t monero_fee_utils::estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
+size_t monero_fee_utils::estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag)
 {
 	size_t size = 0;
 	
@@ -172,8 +172,11 @@ size_t monero_fee_utils::estimate_rct_tx_size(int n_inputs, int mixin, int n_out
 	else
 		size += (2*64*32+32+64*32) * n_outputs;
 	
-	// MGs
-	size += n_inputs * (64 * (mixin+1) + 32);
+  	// MGs/CLSAGs
+	if (clsag)
+		size += n_inputs * (32 * (mixin+1) + 64);
+	else
+		size += n_inputs * (64 * (mixin+1) + 32);
 	
 	// mixRing - not serialized, can be reconstructed
 	/* size += 2 * 32 * (mixin+1) * n_inputs; */
@@ -181,25 +184,25 @@ size_t monero_fee_utils::estimate_rct_tx_size(int n_inputs, int mixin, int n_out
 	// pseudoOuts
 	size += 32 * n_inputs;
 	// ecdhInfo
-	size += 2 * 32 * n_outputs;
-	// outPk - only commitment is saved
-	size += 32 * n_outputs;
-	// txnFee
-	size += 4;
+	size += 8 * n_outputs;
+	// outPk/_usd/_xasset - only commitment is saved
+	size += 32 * n_outputs * 3;
+	// txnFee / txnOffshoreFee for all 3 units (XHV, XUSD, xAsset)
+	size += (4 * 6);
 	
 	LOG_PRINT_L2("estimated " << (bulletproof ? "bulletproof" : "borromean") << " rct tx size for " << n_inputs << " inputs with ring size " << (mixin+1) << " and " << n_outputs << " outputs: " << size << " (" << ((32 * n_inputs/*+1*/) + 2 * 32 * (mixin+1) * n_inputs + 32 * n_outputs) << " saved)");
 	return size;
 }
-size_t monero_fee_utils::estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
+size_t monero_fee_utils::estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag)
 {
 	if (use_rct)
-		return estimate_rct_tx_size(n_inputs, mixin, n_outputs, extra_size, bulletproof);
+		return estimate_rct_tx_size(n_inputs, mixin, n_outputs, extra_size, bulletproof, clsag);
 	else
 		return n_inputs * (mixin+1) * APPROXIMATE_INPUT_BYTES + extra_size;
 }
-uint64_t monero_fee_utils::estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
+uint64_t monero_fee_utils::estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag)
 {
-	size_t size = estimate_tx_size(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof);
+	size_t size = estimate_tx_size(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof, clsag);
 	if (use_rct && bulletproof && n_outputs > 2)
 	{
 		const uint64_t bp_base = 368;
@@ -214,16 +217,16 @@ uint64_t monero_fee_utils::estimate_tx_weight(bool use_rct, int n_inputs, int mi
 	}
 	return size;
 }
-uint64_t monero_fee_utils::estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask)
+uint64_t monero_fee_utils::estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask)
 {
 	if (use_per_byte_fee)
 	{
-		const size_t estimated_tx_weight = estimate_tx_weight(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof);
+		const size_t estimated_tx_weight = estimate_tx_weight(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof, clsag);
 		return calculate_fee_from_weight(base_fee, estimated_tx_weight, fee_multiplier, fee_quantization_mask);
 	}
 	else
 	{
-		const size_t estimated_tx_size = estimate_tx_size(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof);
+		const size_t estimated_tx_size = estimate_tx_size(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof, clsag);
 		return calculate_fee_from_size(base_fee, estimated_tx_size, fee_multiplier);
 	}
 }

--- a/src/monero_fee_utils.hpp
+++ b/src/monero_fee_utils.hpp
@@ -57,16 +57,16 @@ namespace monero_fee_utils
 	int get_fee_algorithm(use_fork_rules_fn_type use_fork_rules_fn);
 	uint64_t get_base_fee(uint64_t fee_per_b);
 	//
-	uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
+	uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
 	//
 	uint64_t calculate_fee_from_weight(uint64_t base_fee, uint64_t weight, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
 	uint64_t calculate_fee(bool use_per_byte_fee, const cryptonote::transaction &tx, size_t blob_size, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
 	//
 	/*Added*/ uint64_t calculate_fee_from_size(uint64_t fee_per_b, size_t bytes, uint64_t fee_multiplier);
 	//
-	size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof);
-	uint64_t estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof);
-	size_t estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof);
+	size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
+	uint64_t estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
+	size_t estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
 	uint64_t estimated_tx_network_fee( // convenience function for size + calc
 		uint64_t fee_per_b,
 		uint32_t priority, // when priority=0, falls back to monero_fee_utils::default_priority()

--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -72,13 +72,15 @@ optional<uint64_t> _possible_uint64_from_json(
 //
 LightwalletAPI_Req_GetUnspentOuts monero_send_routine::new__req_params__get_unspent_outs(
 	string from_address_string,
-	string sec_viewKey_string
+	string sec_viewKey_string,
+	string from_asset_type
 ) {
 	ostringstream dustT_ss;
 	dustT_ss << dust_threshold();
 	return {
 		std::move(from_address_string),
 		std::move(sec_viewKey_string),
+		std::move(from_asset_type),
 		"0", // amount - always sent as "0"
 		fixed_mixinsize(),
 		true, // use dust
@@ -109,7 +111,8 @@ LightwalletAPI_Res_GetUnspentOuts monero_send_routine::new__parsed_res__get_unsp
 	const property_tree::ptree &res,
 	const secret_key &sec_viewKey,
 	const secret_key &sec_spendKey,
-	const public_key &pub_spendKey
+	const public_key &pub_spendKey,
+	string from_asset_type
 ) {
 	uint64_t final__per_byte_fee = 0;
 	uint64_t fee_mask = 10000; // just a fallback value - no real reason to set this here normally
@@ -299,6 +302,8 @@ struct _SendFunds_ConstructAndSendTx_Args
 	const string &sec_viewKey_string;
 	const string &sec_spendKey_string;
 	const string &to_address_string;
+	const string &from_asset_type;
+	const string &to_asset_type;
 	optional<string> payment_id_string;
 	uint64_t sending_amount;
 	bool is_sweeping;
@@ -314,6 +319,8 @@ struct _SendFunds_ConstructAndSendTx_Args
 	const vector<SpendableOutput> &unspent_outs;
 	uint64_t fee_per_b;
 	uint64_t fee_quantization_mask;
+	uint64_t blockchain_height;
+	offshore::pricing_record pr;
 	uint8_t fork_version;
 	//
 	// cached
@@ -338,14 +345,18 @@ void _reenterable_construct_and_send_tx(
 	monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 		step1_retVals,
 		//
+		args.from_asset_type,
+		args.to_asset_type,
 		args.payment_id_string,
 		args.sending_amount,
 		args.is_sweeping,
 		args.simple_priority,
+		args.pr,
 		use_fork_rules,
 		args.unspent_outs,
 		args.fee_per_b,
 		args.fee_quantization_mask,
+		args.nettype,
 		//
 		passedIn_attemptAt_fee // use this for passing step2 "must-reconstruct" return values back in, i.e. re-entry; when nil, defaults to attempt at network min
 	);
@@ -380,6 +391,8 @@ void _reenterable_construct_and_send_tx(
 			args.sec_viewKey_string,
 			args.sec_spendKey_string,
 			args.to_address_string,
+			args.from_asset_type,
+			args.to_asset_type,
 			args.payment_id_string,
 			step1_retVals.final_total_wo_fee,
 			step1_retVals.change_amount,
@@ -389,6 +402,8 @@ void _reenterable_construct_and_send_tx(
 			args.fee_per_b,
 			args.fee_quantization_mask,
 			*(parsed_res.mix_outs),
+			args.blockchain_height,
+			args.pr,
 			std::move(use_fork_rules),
 			args.unlock_time,
 			args.nettype
@@ -509,7 +524,8 @@ void monero_send_routine::async__send_funds(Async_SendFunds_Args args)
 	) -> void {
 		auto parsed_res = new__parsed_res__get_unspent_outs(
 			res,
-			sec_viewKey, sec_spendKey, pub_spendKey
+			sec_viewKey, sec_spendKey, pub_spendKey,
+			args.from_asset_type
 		);
 		if (parsed_res.err_msg != none) {
 			SendFunds_Error_RetVals error_retVals;
@@ -519,7 +535,8 @@ void monero_send_routine::async__send_funds(Async_SendFunds_Args args)
 		}
 		_reenterable_construct_and_send_tx(_SendFunds_ConstructAndSendTx_Args{
 			args.from_address_string, args.sec_viewKey_string, args.sec_spendKey_string,
-			args.to_address_string, args.payment_id_string, usable__sending_amount, args.is_sweeping, args.simple_priority,
+			args.to_address_string, args.from_asset_type, args.to_asset_type,
+			args.payment_id_string, usable__sending_amount, args.is_sweeping, args.simple_priority,
 			args.get_random_outs_fn, args.submit_raw_tx_fn, args.status_update_fn, args.error_cb_fn, args.success_cb_fn,
 			args.unlock_time == none ? 0 : *(args.unlock_time),
 			args.nettype == none ? MAINNET : *(args.nettype),
@@ -527,6 +544,7 @@ void monero_send_routine::async__send_funds(Async_SendFunds_Args args)
 			*(parsed_res.unspent_outs),
 			*(parsed_res.per_byte_fee),
 			*(parsed_res.fee_mask),
+			args.blockchain_height, args.pr,
 			parsed_res.fork_version,
 			//
 			sec_viewKey, sec_spendKey
@@ -537,7 +555,8 @@ void monero_send_routine::async__send_funds(Async_SendFunds_Args args)
 	args.get_unspent_outs_fn(
 		new__req_params__get_unspent_outs(
 			args.from_address_string,
-			args.sec_viewKey_string
+			args.sec_viewKey_string,
+			args.from_asset_type
 		),
 		get_unspent_outs_fn__cb_fn
 	);

--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -356,7 +356,6 @@ void _reenterable_construct_and_send_tx(
 		args.unspent_outs,
 		args.fee_per_b,
 		args.fee_quantization_mask,
-		args.nettype,
 		//
 		passedIn_attemptAt_fee // use this for passing step2 "must-reconstruct" return values back in, i.e. re-entry; when nil, defaults to attempt at network min
 	);

--- a/src/monero_send_routine.hpp
+++ b/src/monero_send_routine.hpp
@@ -64,6 +64,7 @@ namespace monero_send_routine
 	{ // strings are NOT references, so they get copied, allowing scope of struct init not to be an issue
 		const string address;
 		const string view_key;
+		const string asset_type;
 		const string amount; // "0" uint64_string
 		size_t mixin;
 		bool use_dust; // true; send-funds is now coded to filter unmixable and below threshold dust properly when sweeping and not sweeping
@@ -74,6 +75,7 @@ namespace monero_send_routine
 		boost::property_tree::ptree req_params_root;
 		req_params_root.put("address", req_params.address);
 		req_params_root.put("view_key", req_params.view_key);
+		req_params_root.put("asset_type", req_params.asset_type);
 		req_params_root.put("amount", req_params.amount);
 		req_params_root.put("dust_threshold", req_params.dust_threshold);
 		req_params_root.put("use_dust", req_params.use_dust);
@@ -85,7 +87,8 @@ namespace monero_send_routine
 	}
 	LightwalletAPI_Req_GetUnspentOuts new__req_params__get_unspent_outs( // used internally and by emscr async send impl
 		string from_address_string,
-		string sec_viewKey_string
+		string sec_viewKey_string,
+		string from_asset_type
 	);
 	typedef std::function<void(
 		LightwalletAPI_Req_GetUnspentOuts, // req_params - use these for making the request
@@ -214,7 +217,8 @@ namespace monero_send_routine
 		const property_tree::ptree &res,
 		const secret_key &sec_viewKey,
 		const secret_key &sec_spendKey,
-		const public_key &pub_spendKey
+		const public_key &pub_spendKey,
+		string from_asset_type
 	);
 	LightwalletAPI_Res_GetRandomOuts new__parsed_res__get_random_outs(
 		const property_tree::ptree &res
@@ -228,10 +232,14 @@ namespace monero_send_routine
 		string sec_spendKey_string;
 		string pub_spendKey_string;
 		string to_address_string;
+		string from_asset_type;
+		string to_asset_type;
 		optional<string> payment_id_string;
 		uint64_t sending_amount;
 		bool is_sweeping;
 		uint32_t simple_priority;
+		uint64_t blockchain_height;
+		offshore::pricing_record pr;
 		send__get_unspent_outs_fn_type get_unspent_outs_fn;
 		send__get_random_outs_fn_type get_random_outs_fn;
 		send__submit_raw_tx_fn_type submit_raw_tx_fn;

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -381,7 +381,6 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	const vector<SpendableOutput> &unspent_outs,
 	uint64_t fee_per_b, // per v8
 	uint64_t fee_quantization_mask,
-	cryptonote::network_type nettype,
 	//
 	optional<uint64_t> passedIn_attemptAt_fee
 ) {

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -36,6 +36,7 @@
 #include "string_tools.h"
 #include "monero_paymentID_utils.hpp"
 #include "monero_key_image_utils.hpp"
+#include "offshore/asset_types.h"
 //
 using namespace std;
 using namespace crypto;
@@ -193,6 +194,146 @@ bool _verify_sec_key(const crypto::secret_key &secret_key, const crypto::public_
 	bool r = crypto::secret_key_to_public_key(secret_key, calculated_pub);
 	return r && public_key == calculated_pub;
 }
+//----------------------------------------------------------------------------------------------------
+uint64_t get_xasset_amount(const uint64_t xusd_amount, const std::string asset_type, offshore::pricing_record pr)
+{ // borrowed from wallet2.cpp
+	boost::multiprecision::uint128_t xusd_128 = xusd_amount;
+	boost::multiprecision::uint128_t exchange_128 =
+		asset_type == "XAG" ? pr.xAG :
+		asset_type == "XAU" ? pr.xAU :
+		asset_type == "XAUD" ? pr.xAUD :
+		asset_type == "XBTC" ? pr.xBTC :
+		asset_type == "XCAD" ? pr.xCAD :
+		asset_type == "XCHF" ? pr.xCHF :
+		asset_type == "XCNY" ? pr.xCNY :
+		asset_type == "XEUR" ? pr.xEUR :
+		asset_type == "XGBP" ? pr.xGBP :
+		asset_type == "XJPY" ? pr.xJPY :
+		asset_type == "XNOK" ? pr.xNOK :
+		asset_type == "XNZD" ? pr.xNZD :
+		asset_type == "XUSD" ? pr.xUSD :
+		pr.unused1;
+	boost::multiprecision::uint128_t xasset_128 = xusd_128 * exchange_128;
+	xasset_128 /= 1000000000000;
+	return (uint64_t)xasset_128;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_xusd_amount(const uint64_t amount, const std::string asset_type, offshore::pricing_record pr)
+{ // borrowed from wallet2.cpp
+	boost::multiprecision::uint128_t amount_128 = amount;
+	boost::multiprecision::uint128_t exchange_128 =
+		asset_type == "XAG" ? pr.xAG :
+		asset_type == "XAU" ? pr.xAU :
+		asset_type == "XAUD" ? pr.xAUD :
+		asset_type == "XBTC" ? pr.xBTC :
+		asset_type == "XCAD" ? pr.xCAD :
+		asset_type == "XCHF" ? pr.xCHF :
+		asset_type == "XCNY" ? pr.xCNY :
+		asset_type == "XEUR" ? pr.xEUR :
+		asset_type == "XGBP" ? pr.xGBP :
+		asset_type == "XJPY" ? pr.xJPY :
+		asset_type == "XNOK" ? pr.xNOK :
+		asset_type == "XNZD" ? pr.xNZD :
+		asset_type == "XHV" ? pr.unused1 :
+		pr.unused1;
+    if (asset_type == "XHV") {
+      boost::multiprecision::uint128_t xusd_128 = amount_128 * exchange_128;
+      xusd_128 /= 1000000000000;
+      return (uint64_t)xusd_128;
+    } else {
+      boost::multiprecision::uint128_t xusd_128 = amount_128 * 1000000000000;
+      xusd_128 /= exchange_128;
+      return (uint64_t)xusd_128;
+    }
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_offshore_fee(uint64_t amount, uint32_t priority)
+{ // borrowed from wallet2.cpp
+	uint64_t fee_estimate = amount;
+	switch(priority) {
+		case 4:
+			fee_estimate /= 5; // 20% - "workday rush"
+			break;
+		case 3:
+			fee_estimate /= 10; // 10% "1-day rush"
+			break;
+		case 2:
+			fee_estimate /= 20; // 5% - "premium mint"
+			break;
+		default:
+			fee_estimate /= 500; // 0.2% - "standard mint"
+			break;
+	}
+
+	// Return the fee
+	return fee_estimate;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_onshore_fee(uint64_t amount, uint32_t priority)
+{
+	uint64_t fee_estimate = amount;
+	switch(priority) {
+		case 4:
+			fee_estimate /= 5; // 20% - "workday rush"
+			break;
+		case 3:
+			fee_estimate /= 10; // 10% "1-day rush"
+			break;
+		case 2:
+			fee_estimate /= 20; // 5% - "premium mint"
+			break;
+		default:
+			fee_estimate /= 500; // 0.2% - "standard mint"
+			break;
+	}
+
+	// Return the fee
+	return fee_estimate;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_offshore_to_offshore_fee(uint64_t amount, uint32_t priority)
+{
+  return 0;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_xasset_to_xusd_fee(uint64_t amount, uint32_t priority, use_fork_rules_fn_type use_fork_rules_fn)
+{
+  if (use_fork_rules_fn(HF_VERSION_OFFSHORE_FEES_V3, 0)) {
+    return (amount * 3) / 1000;
+  }
+
+  return 0;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_xasset_transfer_fee(uint64_t amount, uint32_t priority)
+{
+  return 0;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t get_xusd_to_xasset_fee(uint64_t amount, uint32_t priority, use_fork_rules_fn_type use_fork_rules_fn)
+{
+  if (use_fork_rules_fn(HF_VERSION_OFFSHORE_FEES_V3, 0)) {
+    return (amount * 3) / 1000;
+  }
+
+  return 0;
+}
+//----------------------------------------------------------------------------------------------------
+uint64_t convert_fee_to_source_asset_type(uint64_t fee, string from_asset_type, offshore::pricing_record pr)
+{
+  	// Fee estimate is in XHV - if necessary, convert to same currency as source asset
+	if (from_asset_type != "XHV") {
+		uint64_t fee_xusd_amount = get_xusd_amount(fee, "XHV", pr);
+
+		if (from_asset_type == "XUSD") {
+			fee = fee_xusd_amount;
+		} else {
+			fee = get_xasset_amount(fee_xusd_amount, from_asset_type, pr);
+		}
+	}
+
+	return fee;
+}
 } // unnamed namespace
 //
 namespace
@@ -228,15 +369,19 @@ namespace
 void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	Send_Step1_RetVals &retVals,
 	//
+	const string &from_asset_type,
+	const string &to_asset_type,
 	const optional<string>& payment_id_string,
 	uint64_t sending_amount,
 	bool is_sweeping,
 	uint32_t simple_priority,
+	offshore::pricing_record pr,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	//
 	const vector<SpendableOutput> &unspent_outs,
 	uint64_t fee_per_b, // per v8
 	uint64_t fee_quantization_mask,
+	cryptonote::network_type nettype,
 	//
 	optional<uint64_t> passedIn_attemptAt_fee
 ) {
@@ -262,6 +407,7 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	//
 	bool use_rct = true;
 	bool bulletproof = true;
+	bool clsag = true;
 	//
 	std::vector<uint8_t> extra;
 	CreateTransactionErrorCode tx_extra__code = _add_pid_to_tx_extra(payment_id_string, extra);
@@ -269,30 +415,95 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 		retVals.errCode = tx_extra__code;
 		return;
 	}
+	
+	// determine if transaction is offshore and if so what type
+	bool offshore = false;
+	bool onshore = false;
+	bool offshore_transfer = false;
+	bool xasset_transfer = false;
+	bool xasset_to_xusd = false;
+	bool xusd_to_xasset = false;
+    if (from_asset_type != "XHV" || to_asset_type != "XHV") {
+		// Populate the txextra to signify that this is an offshore tx
+		std::string offshore_data = from_asset_type + "-" + to_asset_type;
+    	cryptonote::add_offshore_to_tx_extra(extra, offshore_data);
+
+        if (from_asset_type == "XHV") {
+          offshore = true;
+        } else if (to_asset_type == "XHV") {
+          onshore = true;
+        } else if ((from_asset_type == "XUSD") && (to_asset_type == "XUSD")) {
+          offshore_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xUSD transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if ((from_asset_type != "XUSD") && (to_asset_type != "XUSD")) {
+          xasset_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xAsset transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if (from_asset_type == "XUSD") {
+          xusd_to_xasset = true;
+        } else {
+          xasset_to_xusd = true;
+        }
+	}
+
+	if (offshore || onshore || xusd_to_xasset || xasset_to_xusd) {
+      // Only permit input amounts to 4 decimal places, to avoid precision / truncation errors
+      THROW_WALLET_EXCEPTION_IF(sending_amount % 100000000, error::wallet_internal_error, "Offshore/xAsset TX amounts permit at most 4 decimal places");
+	}
+
 	const uint64_t base_fee = get_base_fee(fee_per_b); // in other words, fee_per_b
 	const uint64_t fee_multiplier = get_fee_multiplier(simple_priority, default_priority(), get_fee_algorithm(use_fork_rules_fn), use_fork_rules_fn);
 	//
 	uint64_t attempt_at_min_fee;
 	if (passedIn_attemptAt_fee == none) {
-		attempt_at_min_fee = estimate_fee(true/*use_per_byte_fee*/, true/*use_rct*/, 2/*est num inputs*/, fake_outs_count, 2, extra.size(), bulletproof, base_fee, fee_multiplier, fee_quantization_mask);
+		uint64_t attempt_at_min_fee = estimate_fee(true/*use_per_byte_fee*/, true/*use_rct*/, 2/*est num inputs*/, fake_outs_count, 2, extra.size(), bulletproof, clsag, base_fee, fee_multiplier, fee_quantization_mask);
 		// opted to do this instead of `const uint64_t min_fee = (fee_multiplier * base_fee * estimate_tx_size(use_rct, 1, fake_outs_count, 2, extra.size(), bulletproof));`
 		// TODO: estimate with 1 input or 2?
+		attempt_at_min_fee = convert_fee_to_source_asset_type(attempt_at_min_fee, from_asset_type, pr);
 	} else {
 		attempt_at_min_fee = *passedIn_attemptAt_fee;
 	}
-	struct Total
-	{
-		static uint64_t with(uint64_t sending_amount, uint64_t fee_amount)
-		{
-			return sending_amount + fee_amount;
-		}
-	};
+
+	// convert sending_amount to source asset type to use in the search for inputs from unspent outs
+	uint64_t sending_amount_in_source_currency;
+	if (offshore) {
+		// Input amount is in XHV - no conversion needed
+		sending_amount_in_source_currency = sending_amount;		
+	} else if (onshore) {
+		// Input amount is in XHV - convert to XUSD
+		sending_amount_in_source_currency = get_xusd_amount(sending_amount, to_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(sending_amount_in_source_currency == 0, error::wallet_internal_error, "Failed to convert sending_amount back to xUSD");
+	} else if (offshore_transfer) {
+		// Input amount is in XUSD - no conversion needed
+		sending_amount_in_source_currency = sending_amount;
+	} else if (xusd_to_xasset) {
+		// Input amount is in XUSD - no conversion needed
+		sending_amount_in_source_currency = sending_amount;
+	} else if (xasset_to_xusd) {
+		// Input amount is in XUSD - convert to XASSET
+		sending_amount_in_source_currency = get_xasset_amount(sending_amount, from_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(sending_amount_in_source_currency == 0, error::wallet_internal_error, "Failed to convert sending_amount to xAsset");
+	} else if (xasset_transfer) {
+		// Input amount is in XASSET - no conversion needed
+		sending_amount_in_source_currency = sending_amount;
+	} else {
+		// Input amount is in XHV - no conversion needed
+		sending_amount_in_source_currency = sending_amount;
+	}
+
 	// fee may get changed as follows…
 	uint64_t potential_total; // aka balance_required
 	if (is_sweeping) {
 		potential_total = UINT64_MAX; // balance required: all
 	} else {
-		potential_total = Total::with(sending_amount, attempt_at_min_fee);
+		potential_total = sending_amount_in_source_currency + attempt_at_min_fee;
 	}
 	//
 	// Gather outputs and amount to use for getting decoy outputs…
@@ -324,8 +535,20 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	uint64_t needed_fee = estimate_fee(
 		true/*use_per_byte_fee*/, use_rct,
 		retVals.using_outs.size(), fake_outs_count, /*tx.dsts.size()*/1+1, extra.size(),
-		bulletproof, base_fee, fee_multiplier, fee_quantization_mask
+		bulletproof, clsag, base_fee, fee_multiplier, fee_quantization_mask
 	);
+	needed_fee = convert_fee_to_source_asset_type(needed_fee, from_asset_type, pr);
+	// Calculate the offshore fee
+	uint64_t total_for_offshore_fee = is_sweeping ? using_outs_amount : sending_amount_in_source_currency;
+	uint64_t offshore_fee = (offshore) ? get_offshore_fee(total_for_offshore_fee, simple_priority)
+		: (onshore) ? get_onshore_fee(total_for_offshore_fee, simple_priority)
+		: (offshore_transfer) ? get_offshore_to_offshore_fee(total_for_offshore_fee, 4)
+		: (xusd_to_xasset) ? get_xusd_to_xasset_fee(total_for_offshore_fee, simple_priority, use_fork_rules_fn)
+		: (xasset_to_xusd) ? get_xasset_to_xusd_fee(total_for_offshore_fee, simple_priority, use_fork_rules_fn)
+		: (xasset_transfer) ? get_xasset_transfer_fee(total_for_offshore_fee, simple_priority)
+		: 0;
+	needed_fee += offshore_fee;
+	//
 	// if newNeededFee < neededFee, use neededFee instead (should only happen on the 2nd or later times through (due to estimated fee being too low))
 	if (needed_fee < attempt_at_min_fee) {
 		needed_fee = attempt_at_min_fee;
@@ -337,7 +560,7 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	//
 	uint64_t total_wo_fee = is_sweeping
 		? /*now that we know outsAmount>needed_fee*/(using_outs_amount - needed_fee)
-		: sending_amount;
+		: sending_amount_in_source_currency;
 	retVals.final_total_wo_fee = total_wo_fee;
 	//
 	uint64_t total_incl_fees;
@@ -348,7 +571,7 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 		}
 		total_incl_fees = using_outs_amount;
 	} else {
-		total_incl_fees = sending_amount + needed_fee; // because fee changed because using_outs.size() was updated
+		total_incl_fees = sending_amount_in_source_currency + needed_fee; // because fee changed because using_outs.size() was updated
 		while (using_outs_amount < total_incl_fees && remaining_unusedOuts.size() > 0) { // add outputs 1 at a time till we either have them all or can meet the fee
 			{
 				auto out = pop_random_value(remaining_unusedOuts);
@@ -362,9 +585,10 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 			needed_fee = estimate_fee(
 				true/*use_per_byte_fee*/, use_rct,
 				retVals.using_outs.size(), fake_outs_count, /*tx.dsts.size()*/1+1, extra.size(),
-				bulletproof, base_fee, fee_multiplier, fee_quantization_mask
+				bulletproof, clsag, base_fee, fee_multiplier, fee_quantization_mask
 			);
-			total_incl_fees = sending_amount + needed_fee; // because fee changed
+			needed_fee = offshore_fee + convert_fee_to_source_asset_type(needed_fee, from_asset_type, pr);
+			total_incl_fees = sending_amount_in_source_currency + needed_fee; // because fee changed
 		}
 		retVals.required_balance = total_incl_fees; // update required_balance b/c total_incl_fees changed
 	}
@@ -381,7 +605,7 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 	uint64_t change_amount = 0; // to initialize
 	if (using_outs_amount > total_incl_fees) {
 		THROW_WALLET_EXCEPTION_IF(is_sweeping, error::wallet_internal_error, "Unexpected total_incl_fees > using_outs_amount while sweeping");
-		change_amount = using_outs_amount - total_incl_fees;
+		change_amount = using_outs_amount - total_incl_fees; // change amount is in source currency type
 	}
 //	cout << "Calculated change amount:" << change_amount << endl;
 	retVals.change_amount = change_amount;
@@ -398,6 +622,8 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 	const string &sec_viewKey_string,
 	const string &sec_spendKey_string,
 	const string &to_address_string,
+	const string &from_asset_type,
+	const string &to_asset_type,
 	const optional<string>& payment_id_string,
 	uint64_t final_total_wo_fee,
 	uint64_t change_amount,
@@ -407,6 +633,8 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 	uint64_t fee_per_b, // per v8
 	uint64_t fee_quantization_mask,
 	vector<RandomAmountOutputs> &mix_outs, // cannot be const due to convenience__create_transaction's mutability requirement
+	uint64_t current_height,
+	offshore::pricing_record pr,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time, // or 0
 	cryptonote::network_type nettype
@@ -418,9 +646,12 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 		create_tx__retVals,
 		from_address_string,
 		sec_viewKey_string, sec_spendKey_string,
-		to_address_string, payment_id_string,
-		final_total_wo_fee, change_amount, fee_amount,
+		to_address_string, 
+		from_asset_type, to_asset_type,
+		payment_id_string,
+		final_total_wo_fee, change_amount, fee_amount, simple_priority,
 		using_outs, mix_outs,
+		current_height, pr,
 		use_fork_rules_fn,
 		unlock_time,
 		nettype // TODO: move to after from_address_string
@@ -431,6 +662,45 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 	}
 	THROW_WALLET_EXCEPTION_IF(create_tx__retVals.signed_serialized_tx_string == boost::none, error::wallet_internal_error, "Not expecting no signed_serialized_tx_string given no error");
 	//
+	bool offshore = false;
+	bool onshore = false;
+	bool offshore_transfer = false;
+	bool xasset_transfer = false;
+	bool xasset_to_xusd = false;
+	bool xusd_to_xasset = false;
+    if (from_asset_type != "XHV" || to_asset_type != "XHV") {
+        if (from_asset_type == "XHV") {
+          offshore = true;
+        } else if (to_asset_type == "XHV") {
+          onshore = true;
+        } else if ((from_asset_type == "XUSD") && (to_asset_type == "XUSD")) {
+          offshore_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xUSD transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if ((from_asset_type != "XUSD") && (to_asset_type != "XUSD")) {
+          xasset_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xAsset transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if (from_asset_type == "XUSD") {
+          xusd_to_xasset = true;
+        } else {
+          xasset_to_xusd = true;
+        }
+	}
+	uint64_t offshore_fee = (offshore) ? get_offshore_fee(final_total_wo_fee, simple_priority)
+		: (onshore) ? get_onshore_fee(final_total_wo_fee, simple_priority)
+		: (offshore_transfer) ? get_offshore_to_offshore_fee(final_total_wo_fee, 4)
+		: (xusd_to_xasset) ? get_xusd_to_xasset_fee(final_total_wo_fee, simple_priority, use_fork_rules_fn)
+		: (xasset_to_xusd) ? get_xasset_to_xusd_fee(final_total_wo_fee, simple_priority, use_fork_rules_fn)
+		: (xasset_transfer) ? get_xasset_transfer_fee(final_total_wo_fee, simple_priority)
+		: 0;
+	//
 	size_t blob_size = *create_tx__retVals.txBlob_byteLength;
 	uint64_t fee_actually_needed = calculate_fee(
 		true/*use_per_byte_fee*/,
@@ -439,6 +709,8 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 		get_fee_multiplier(simple_priority, default_priority(), get_fee_algorithm(use_fork_rules_fn), use_fork_rules_fn),
 		fee_quantization_mask
 	);
+	fee_actually_needed = convert_fee_to_source_asset_type(fee_actually_needed, from_asset_type, pr);
+	fee_actually_needed += offshore_fee;
 	if (fee_actually_needed > fee_amount) {
 //		cout << "Need to reconstruct tx with fee of at least " << fee_actually_needed << "." << endl;
 		retVals.tx_must_be_reconstructed = true;
@@ -459,13 +731,18 @@ void monero_transfer_utils::create_transaction(
 	const account_keys& sender_account_keys, // this will reference a particular hw::device
 	const uint32_t subaddr_account_idx,
 	const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses,
-	const address_parse_info &to_addr, 
-	uint64_t sending_amount,
+	const address_parse_info &to_addr,
+	const string &from_asset_type,
+	const string &to_asset_type,
+	uint64_t sending_amount_in_source_currency,
 	uint64_t change_amount,
 	uint64_t fee_amount,
+	uint64_t simple_priority,
 	const vector<SpendableOutput> &outputs,
 	vector<RandomAmountOutputs> &mix_outs, 
-	const std::vector<uint8_t> &extra,
+	std::vector<uint8_t> &extra,
+	uint64_t current_height,
+	offshore::pricing_record pr,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time, // or 0
 	bool rct,
@@ -478,11 +755,19 @@ void monero_transfer_utils::create_transaction(
 	uint32_t fake_outputs_count = fixed_mixinsize();
 	bool bulletproof = true;
 	rct::RangeProofType range_proof_type = bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean;
-	int bp_version = bulletproof ? (use_fork_rules_fn(HF_VERSION_SMALLER_BP, -10) ? 2 : 1) : 0;
+	int bp_version = bulletproof ? (use_fork_rules_fn(HF_VERSION_XASSET_FULL, 0) ? 4 : (use_fork_rules_fn(HF_VERSION_CLSAG, 0) ? 3 : (use_fork_rules_fn(HF_VERSION_SMALLER_BP, -10) ? 2 : 1))) : 0;
 	const rct::RCTConfig rct_config {
 		range_proof_type,
 		bp_version,
 	};
+	//
+	// check both from_asset_type and to_asset_type are supported.
+	if (std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), from_asset_type) == offshore::ASSET_TYPES.end()) {
+		THROW_WALLET_EXCEPTION_IF(1, error::wallet_internal_error, "Unsupported Source Asset Type!");
+	}
+	if (std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), to_asset_type) == offshore::ASSET_TYPES.end()) {
+		THROW_WALLET_EXCEPTION_IF(1, error::wallet_internal_error,  "Unsupported Dest Asset Type!");
+	}
 	//
 	if (mix_outs.size() != outputs.size() && fake_outputs_count != 0) {
 		retVals.errCode = wrongNumberOfMixOutsProvided;
@@ -499,13 +784,6 @@ void monero_transfer_utils::create_transaction(
 		retVals.errCode = invalidSecretKeys;
 		return;
 	}
-	if (sending_amount > std::numeric_limits<uint64_t>::max() - change_amount
-		|| sending_amount + change_amount > std::numeric_limits<uint64_t>::max() - fee_amount) {
-		retVals.errCode = outputAmountOverflow;
-		return;
-	}
-	uint64_t needed_money = sending_amount + change_amount + fee_amount; // TODO: is this correct?
-	//
 	uint64_t found_money = 0;
 	std::vector<tx_source_entry> sources;
 	// TODO: log: "Selected transfers: " << outputs
@@ -516,6 +794,7 @@ void monero_transfer_utils::create_transaction(
 		}
 		auto src = tx_source_entry{};
 		src.amount = outputs[out_index].amount;
+		src.asset_type = from_asset_type;
 		src.rct = outputs[out_index].rct != none && (*(outputs[out_index].rct)).empty() == false;
 		//
 		typedef cryptonote::tx_source_entry::output_entry tx_output_entry;
@@ -639,18 +918,100 @@ void monero_transfer_utils::create_transaction(
 		sources.push_back(src);
 	}
 	//
+	// determine if transaction is offshore and if so what type
+	bool offshore = false;
+	bool onshore = false;
+	bool offshore_transfer = false;
+	bool xasset_transfer = false;
+	bool xasset_to_xusd = false;
+	bool xusd_to_xasset = false;
+    if (from_asset_type != "XHV" || to_asset_type != "XHV") {
+		// Populate the txextra to signify that this is an offshore tx
+		std::string offshore_data = from_asset_type + "-" + to_asset_type;
+    	cryptonote::add_offshore_to_tx_extra(extra, offshore_data);
+
+        if (from_asset_type == "XHV") {
+          offshore = true;
+        } else if (to_asset_type == "XHV") {
+          onshore = true;
+        } else if ((from_asset_type == "XUSD") && (to_asset_type == "XUSD")) {
+          offshore_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xUSD transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if ((from_asset_type != "XUSD") && (to_asset_type != "XUSD")) {
+          xasset_transfer = true;
+          if (simple_priority > 1) {
+            // NEAC: force priority of transfers to be low to mitigate the problem from being unable to convert
+            LOG_PRINT_L1("transfer: forcing priority from " << simple_priority << " to LOW - xAsset transfers locked to low priority");
+            simple_priority = 1;
+          }
+        } else if (from_asset_type == "XUSD") {
+          xusd_to_xasset = true;
+        } else {
+          xasset_to_xusd = true;
+        }
+	}
+	//
+    // adjust unlock time for offshore/onshore tx
+    if (offshore ||	onshore) {
+		unlock_time = ((simple_priority == 4) ? 180 : (simple_priority == 3) ? 720 : (simple_priority == 2) ? 1440 : 5040) + current_height;
+    }
+	//
 	// TODO: if this is a multisig wallet, create a list of multisig signers we can use
 	std::vector<cryptonote::tx_destination_entry> splitted_dsts;
-	tx_destination_entry to_dst = AUTO_VAL_INIT(to_dst);
+	cryptonote::tx_destination_entry to_dst = AUTO_VAL_INIT(to_dst);
+	cryptonote::tx_destination_entry change_dst = AUTO_VAL_INIT(change_dst);
+
 	to_dst.addr = to_addr.address;
-	to_dst.amount = sending_amount;
+	to_dst.asset_type = to_asset_type;
+	change_dst.asset_type = from_asset_type;
+
+	// set correct amounts on destination and change outputs
+	if (offshore) {
+		to_dst.amount_usd = get_xusd_amount(sending_amount_in_source_currency, from_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(to_dst.amount_usd == 0, error::wallet_internal_error, "Failed to convert sending_amount_in_source_currency to xUSD");
+		to_dst.amount = sending_amount_in_source_currency;
+		change_dst.amount = change_amount;
+	} else if (onshore) {
+		to_dst.amount = get_xusd_amount(sending_amount_in_source_currency, from_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(to_dst.amount == 0, error::wallet_internal_error, "Failed to convert sending_amount back to xUSD");
+		to_dst.amount_usd = sending_amount_in_source_currency;
+		change_dst.amount_usd = change_amount;
+	} else if (offshore_transfer) {
+		to_dst.amount_usd = sending_amount_in_source_currency;
+		change_dst.amount_usd = change_amount;
+	} else if (xusd_to_xasset) {
+		to_dst.amount_xasset = get_xasset_amount(sending_amount_in_source_currency, to_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(to_dst.amount_xasset == 0, error::wallet_internal_error, "Failed to convert sending_amount to xAsset");
+		to_dst.amount_usd = sending_amount_in_source_currency;
+		change_dst.amount_usd = change_amount;
+	} else if (xasset_to_xusd) {
+		to_dst.amount_usd = get_xusd_amount(sending_amount_in_source_currency, from_asset_type, pr);
+		THROW_WALLET_EXCEPTION_IF(to_dst.amount_usd == 0, error::wallet_internal_error, "Failed to convert sending_amount to xAsset");
+		to_dst.amount_xasset = sending_amount_in_source_currency;
+		change_dst.amount_xasset = change_amount;
+	} else if (xasset_transfer) {
+		to_dst.amount_xasset = sending_amount_in_source_currency;
+		change_dst.amount_xasset = change_amount;
+	} else {
+		to_dst.amount = sending_amount_in_source_currency;
+		change_dst.amount = change_amount;
+	}
+
+	if (sending_amount_in_source_currency > std::numeric_limits<uint64_t>::max() - change_amount
+		|| sending_amount_in_source_currency + change_amount > std::numeric_limits<uint64_t>::max() - fee_amount) {
+		retVals.errCode = outputAmountOverflow;
+		return;
+	}
+	uint64_t needed_money = sending_amount_in_source_currency + change_amount + fee_amount;
+
 	to_dst.is_subaddress = to_addr.is_subaddress;
 	splitted_dsts.push_back(to_dst);
 	//
-	cryptonote::tx_destination_entry change_dst = AUTO_VAL_INIT(change_dst);
-	change_dst.amount = change_amount;
-	//
-	if (change_dst.amount == 0) {
+	if (change_amount == 0) {
 		if (splitted_dsts.size() == 1) {
 			// If the change is 0, send it to a random address, to avoid confusing
 			// the sender with a 0 amount output. We send a 0 amount in order to avoid
@@ -670,7 +1031,7 @@ void monero_transfer_utils::create_transaction(
 	//
 	// TODO: log: "sources: " << sources
 	if (found_money > needed_money) {
-		if (change_dst.amount != fee_amount) {
+		if (found_money - sending_amount_in_source_currency - change_amount != fee_amount) {
 			retVals.errCode = resultFeeNotEqualToGiven; // aka "early fee calculation != later"
 			return; // early
 		}
@@ -682,10 +1043,13 @@ void monero_transfer_utils::create_transaction(
 	cryptonote::transaction tx;
 	crypto::secret_key tx_key;
 	std::vector<crypto::secret_key> additional_tx_keys;
+	uint32_t fees_version = use_fork_rules_fn(HF_VERSION_OFFSHORE_FEES_V3, 0) ? 3 : use_fork_rules_fn(HF_VERSION_OFFSHORE_FEES_V2, 0) ? 2 : 1;
+	bool use_offshore_tx_version = use_fork_rules_fn(HF_VERSION_OFFSHORE_FULL, 0);
 	bool r = cryptonote::construct_tx_and_get_tx_key(
 		sender_account_keys, subaddresses,
 		sources, splitted_dsts, change_dst.addr, extra,
 		tx, unlock_time, tx_key, additional_tx_keys,
+		current_height - 1, pr, fees_version, use_offshore_tx_version, 
 		true, rct_config,
 		/*m_multisig ? &msout : */NULL
 	);
@@ -714,12 +1078,17 @@ void monero_transfer_utils::convenience__create_transaction(
 	const string &sec_viewKey_string,
 	const string &sec_spendKey_string,
 	const string &to_address_string,
+	const string &from_asset_type,
+	const string &to_asset_type,
 	const optional<string>& payment_id_string,
-	uint64_t sending_amount,
+	uint64_t sending_amount_in_source_currency,
 	uint64_t change_amount,
 	uint64_t fee_amount,
+	uint64_t simple_priority,
 	const vector<SpendableOutput> &outputs,
 	vector<RandomAmountOutputs> &mix_outs,
+	uint64_t current_height,
+	offshore::pricing_record pr,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time,
 	network_type nettype
@@ -790,9 +1159,11 @@ void monero_transfer_utils::convenience__create_transaction(
 		actualCall_retVals,
 		account_keys, subaddr_account_idx, subaddresses,
 		to_addr_info,
-		sending_amount, change_amount, fee_amount,
+		from_asset_type, to_asset_type,
+		sending_amount_in_source_currency, change_amount, fee_amount, simple_priority,
 		outputs, mix_outs,
 		extra, // TODO: move to after address
+		current_height, pr,
 		use_fork_rules_fn,
 		unlock_time, true/*rct*/, nettype
 	);

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -204,7 +204,6 @@ namespace monero_transfer_utils
 		const vector<SpendableOutput> &unspent_outs,
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,
-		cryptonote::network_type nettype,
 		//
 		optional<uint64_t> passedIn_attemptAt_fee // use this for passing step2 "must-reconstruct" return values back in, i.e. re-entry; when nil, defaults to attempt at network min
 	);

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -63,6 +63,9 @@ namespace monero_transfer_utils
 	struct SpendableOutput
 	{
 		uint64_t amount;
+		uint64_t amount_usd;
+		uint64_t amount_xasset;
+		string asset_type;
 		string public_key;
 		optional<string> rct;
 		uint64_t global_index;
@@ -189,15 +192,19 @@ namespace monero_transfer_utils
 	void send_step1__prepare_params_for_get_decoys(
 		Send_Step1_RetVals &retVals,
 		//
+		const string &from_asset_type,
+		const string &to_asset_type,
 		const optional<string>& payment_id_string,
 		uint64_t sending_amount,
 		bool is_sweeping,
 		uint32_t simple_priority,
+		offshore::pricing_record pr,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		//
 		const vector<SpendableOutput> &unspent_outs,
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,
+		cryptonote::network_type nettype,
 		//
 		optional<uint64_t> passedIn_attemptAt_fee // use this for passing step2 "must-reconstruct" return values back in, i.e. re-entry; when nil, defaults to attempt at network min
 	);
@@ -223,6 +230,8 @@ namespace monero_transfer_utils
 		const string &sec_viewKey_string,
 		const string &sec_spendKey_string,
 		const string &to_address_string,
+		const string &from_asset_type,
+		const string &to_asset_type,
 		const optional<string>& payment_id_string,
 		uint64_t final_total_wo_fee, // this gets passed to create_transaction's 'sending_amount'
 		uint64_t change_amount,
@@ -232,6 +241,8 @@ namespace monero_transfer_utils
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,
 		vector<RandomAmountOutputs> &mix_outs, // it gets sorted
+		uint64_t current_height,
+		offshore::pricing_record pr,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time, // or 0
 		cryptonote::network_type nettype
@@ -257,12 +268,17 @@ namespace monero_transfer_utils
 		const string &sec_viewKey_string,
 		const string &sec_spendKey_string,
 		const string &to_address_string,
+		const string &from_asset_type,
+		const string &to_asset_type,
 		const optional<string>& payment_id_string,
 		uint64_t sending_amount,
 		uint64_t change_amount,
 		uint64_t fee_amount,
+		uint64_t simple_priority,
 		const vector<SpendableOutput> &outputs,
 		vector<RandomAmountOutputs> &mix_outs, // get sorted
+		uint64_t current_height,
+		offshore::pricing_record pr,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time							= 0, // or 0
 		network_type nettype 							= MAINNET
@@ -281,12 +297,17 @@ namespace monero_transfer_utils
 		const uint32_t subaddr_account_idx, // pass 0 for no subaddrs
 		const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses,
 		const address_parse_info &to_addr, // this _must_ include correct .is_subaddr
+		const string &from_asset_type,
+		const string &to_asset_type,
 		uint64_t sending_amount,
 		uint64_t change_amount,
 		uint64_t fee_amount,
+		uint64_t simple_priority,
 		const vector<SpendableOutput> &outputs,
 		vector<RandomAmountOutputs> &mix_outs,
-		const std::vector<uint8_t> &extra, // this is not declared const b/c it may have the output tx pub key appended to it
+		std::vector<uint8_t> &extra, // this is not declared const b/c it may have offshore data added to it
+		uint64_t current_height,
+		offshore::pricing_record pr,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time							= 0, // or 0
 		bool rct 										= true,

--- a/src/monero_wallet_utils.cpp
+++ b/src/monero_wallet_utils.cpp
@@ -298,8 +298,8 @@ bool monero_wallet_utils::wallet_with(
 	account.generate(
 		*decodedSeed_retVals.optl__sec_seed, // is this an extra copy? maybe have consumer pass ref as arg instead
 		true/*recover*/,
-		false/*two_random*/,
-		decodedSeed_retVals.from_legacy16B_lw_seed // assumed set if r
+		false/*two_random*/
+		// decodedSeed_retVals.from_legacy16B_lw_seed // assumed set if r
 	);
 	const cryptonote::account_keys& keys = account.get_keys();
 	retVals.optl__desc = WalletDescription{
@@ -355,8 +355,8 @@ bool monero_wallet_utils::address_and_keys_from_seed(
 	account.generate(
 		sec_seed,
 		true/*recover*/,
-		false/*two_random*/,
-		from_legacy16B_lw_seed // assumed set if r
+		false/*two_random*/
+		// from_legacy16B_lw_seed // assumed set if r
 	);
 	const cryptonote::account_keys& keys = account.get_keys();
 	retVals.optl__val = ComponentsFromSeed{
@@ -485,7 +485,7 @@ bool monero_wallet_utils::validate_wallet_components_with( // returns !did_error
 				coerce_valid_sec_key_from(legacy16B_sec_seed, sec_seed);
 			}
 			cryptonote::account_base expected_account{}; // this initializes the wallet and should call the default constructor
-			expected_account.generate(sec_seed, true/*recover*/, false/*two_random*/, from_legacy16B_lw_seed);
+			expected_account.generate(sec_seed, true/*recover*/, false/*two_random*/ /*, from_legacy16B_lw_seed*/);
 			const cryptonote::account_keys& expected_account_keys = expected_account.get_keys();
 			// TODO: assert sec_spendKey initialized?
 			if (expected_account_keys.m_view_secret_key != sec_viewKey) {

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -520,7 +520,6 @@ string serial_bridge::send_step1__prepare_params_for_get_decoys(const string &ar
 		unspent_outs,
 		stoull(json_root.get<string>("fee_per_b")), // per v8
 		stoull(json_root.get<string>("fee_mask")),
-		nettype_from_string(json_root.get<string>("nettype_string")),
 		//
 		optl__passedIn_attemptAt_fee // use this for passing step2 "must-reconstruct" return values back in, i.e. re-entry; when nil, defaults to attempt at network min
 	);


### PR DESCRIPTION
I borrowed a lot of offshore logic from wallet2.cpp, but also needed to make changes of my own to fit the modular structure of the library. Below are 2 major changes I wanted to highlight in particular. The 2nd change is an issue because the code in this PR fails under certain circumstances as described. Was hoping to discuss this.

This library relies on [this code](https://github.com/haven-protocol-org/havenwallet-core-custom/pull/1) to compile and run. Can copy paste that library into `contrib/monero-core-custom`.

### Major change 1 - passing an offshore pricing record as a parameter to send functions

The client needs asset prices to construct transactions, so that it knows how much will be minted/burned upon conversion, how much change to send, how much to pay in fees, etc. As such, the send functions in this library now accept a pricing record. A client relying on this library can request the latest block's pricing record from the haven-wallet-backend` made available in [this PR](https://github.com/haven-protocol-org/havenwallet-backend/pull/3). This request to the backend is necessary because a client using this library is not expected to have blockchain state synced locally - the client relies on the server for blockchain state.

### Major change 2 - calculating the base fee using market prices

I calculated the base fee a bit differently from what I saw in wallet2.cpp, and want to explain my approach. Here is [wallet2's calculation](https://github.com/haven-protocol-org/haven-offshore/blob/77ae2e04a1fb4f12346d1c8a2f538b9c8be5f8ab/patches/src/wallet/wallet2.cpp.patch#L3068-L3080):

```
  const uint64_t base_fee_orig  = get_base_fee();
  uint64_t base_fee = base_fee_orig;
  if (strSource == "XHV") {
  } else if (strSource == "XUSD") {
    // Convert fee to xUSD
    //base_fee = get_xusd_amount(base_fee_orig, "XHV", current_height);
  } else {
    // xAsset TX - is it a conversion?
    if (strSource != strDest) {
      base_fee = get_xasset_amount(get_xusd_amount(base_fee_orig, "XHV", current_height), strSource, current_height);
    }
  }
```

With this code, for the following transaction types (xUSD <> xUSD, xUSD -> xAsset, xAsset <> xAsset), the base fee returned is some absolute number that is identical to the base fee calculated for XHV. However, I believe this undershoots the fee for assets that are valued less than XHV, and overshoots the fee for assets that are valued more than XHV.

If you assume the `base_fee` is 0.1, then an xUSD transfer would have a base fee of 0.1 xUSD (which is worth less than 0.1 XHV), and an xAU transfer would have a base fee of 0.1 xAU (which is worth a lot more than 0.1 XHV). But I figure that fees should all have a relatively similar value - it doesn't seem like it makes sense to me that xAU transfers would give more to miners by default, and xUSD transfers would give less. I figure users would want to incentivize miners to pick up transactions equally by default, regardless of the asset. It seems like this was the intention behind the base fee calculation for conversions from xAssets back to xUSD, but perhaps seems like an oversight for other types of transactions?

To account for the above, I added this function to convert `base_fee_orig` into `base_fee`:

```
uint64_t convert_fee_to_source_asset_type(uint64_t fee, string from_asset_type, offshore::pricing_record pr)
{
  	// Fee estimate is in XHV - if necessary, convert to same currency as source asset
	if (from_asset_type != "XHV") {
		uint64_t fee_xusd_amount = get_xusd_amount(fee, "XHV", pr);

		if (from_asset_type == "XUSD") {
			fee = fee_xusd_amount;
		} else {
			fee = get_xasset_amount(fee_xusd_amount, from_asset_type, pr);
		}
	}

	return fee;
}
```

Unfortunately this presents an issue with my code where xAU transfers don't go through because the fee ends up too far below nodes' [expected minimum fee](https://github.com/monero-project/monero/blob/f6279a633d4bdf46f81fed835656d3386fb9cade/src/cryptonote_core/blockchain.cpp#L3713-L3717). So wanted to call attention to this.
